### PR TITLE
Pokazywanie listy komend po wpisaniu /g bez argumentów

### DIFF
--- a/src/main/java/pl/grzegorz2047/openguild2047/commands/GildiaCommand.java
+++ b/src/main/java/pl/grzegorz2047/openguild2047/commands/GildiaCommand.java
@@ -91,8 +91,7 @@ public class GildiaCommand implements CommandExecutor {
                     return error(sender, "Podano blad w komendzie");
                 }
             } else {
-                sender.sendMessage(ChatColor.DARK_GRAY + " -------------------- " + ChatColor.GOLD + "OpenGuild2047" + ChatColor.DARK_GRAY + " -------------------- ");
-                sender.sendMessage(ChatColor.DARK_GRAY + "Aby uzyskac pomoc dotyczaca gildii uzyj komendy /gildia help.");
+                HelpArg.execute(sender, args);
                 return true;
             }
         }

--- a/src/main/java/pl/grzegorz2047/openguild2047/commands/arguments/HelpArg.java
+++ b/src/main/java/pl/grzegorz2047/openguild2047/commands/arguments/HelpArg.java
@@ -32,7 +32,7 @@ public class HelpArg {
 
     public static boolean execute(CommandSender sender, String[] args) {
         int page = 1;
-        if(args.length == 1) {
+        if(args.length != 2) {
             page = 1;
         } else {
             try {


### PR DESCRIPTION
Dodałem pokazywanie pomocy po wpisaniu komendy /gildia lub /g bez podania jakiegoś argumentu.
Wyświetla się (to co było w /g pomoc).
